### PR TITLE
Re-add f2fs userdata formatting and Switch Slots features to crDroid Recovery in Android 13

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -100,7 +100,6 @@ cc_defaults {
         "libcrypto",
         "libcutils",
         "libfs_mgr",
-        "libhardware",
         "liblp",
         "liblog",
         "libprotobuf-cpp-lite",

--- a/Android.bp
+++ b/Android.bp
@@ -100,6 +100,7 @@ cc_defaults {
         "libcrypto",
         "libcutils",
         "libfs_mgr",
+        "libhardware",
         "liblp",
         "liblog",
         "libprotobuf-cpp-lite",

--- a/install/include/install/wipe_data.h
+++ b/install/include/install/wipe_data.h
@@ -30,4 +30,7 @@ bool WipeCache(RecoveryUI* ui, const std::function<bool()>& confirm);
 bool WipeData(Device* device);
 
 // Returns true on success.
+bool WipeData(Device* device, std::string fs);
+
+// Returns true on success.
 bool WipeSystem(RecoveryUI* ui, const std::function<bool()>& confirm);

--- a/install/wipe_data.cpp
+++ b/install/wipe_data.cpp
@@ -18,7 +18,9 @@
 
 #include <fcntl.h>
 #include <linux/fs.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <sys/ioctl.h>
 
 #include <functional>
@@ -40,8 +42,9 @@ constexpr const char* CACHE_ROOT = "/cache";
 constexpr const char* DATA_ROOT = "/data";
 constexpr const char* METADATA_ROOT = "/metadata";
 
-static bool EraseVolume(const char* volume, RecoveryUI* ui) {
+static bool EraseVolume(const char* volume, RecoveryUI* ui, std::string fs) {
   bool is_cache = (strcmp(volume, CACHE_ROOT) == 0);
+  bool is_data = (strcmp(volume, DATA_ROOT) == 0);
 
   std::vector<saved_log_file> log_files;
   if (is_cache) {
@@ -50,7 +53,7 @@ static bool EraseVolume(const char* volume, RecoveryUI* ui) {
     log_files = ReadLogFilesToMemory();
   }
 
-  ui->Print("Formatting %s...\n", volume);
+  ui->Print("Formatting %s to %s...\n", volume, fs.c_str());
 
   Volume* vol = volume_for_mount_point(volume);
   if (vol->fs_mgr_flags.logical) {
@@ -92,13 +95,22 @@ static bool EraseVolume(const char* volume, RecoveryUI* ui) {
     return false;
   }
 
-  int result = format_volume(volume);
+  int result;
+  if (is_data) {
+    result = format_volume(volume, "", fs);
+  } else {
+    result = format_volume(volume);
+  }
 
   if (is_cache) {
     RestoreLogFilesAfterFormat(log_files);
   }
 
   return (result == 0);
+}
+
+static bool EraseVolume(const char* volume, RecoveryUI* ui) {
+  return EraseVolume(volume, ui, volume_for_mount_point(volume)->fs_type);
 }
 
 bool WipeCache(RecoveryUI* ui, const std::function<bool()>& confirm_func) {
@@ -121,7 +133,7 @@ bool WipeCache(RecoveryUI* ui, const std::function<bool()>& confirm_func) {
   return success;
 }
 
-bool WipeData(Device* device) {
+bool WipeData(Device* device, std::string fs) {
   RecoveryUI* ui = device->GetUI();
   ui->Print("\n-- Wiping data...\n");
   ui->SetBackground(RecoveryUI::ERASING);
@@ -134,7 +146,7 @@ bool WipeData(Device* device) {
 
   bool success = device->PreWipeData();
   if (success) {
-    success &= EraseVolume(DATA_ROOT, ui);
+    success &= EraseVolume(DATA_ROOT, ui, fs);
     bool has_cache = volume_for_mount_point("/cache") != nullptr;
     if (has_cache) {
       success &= EraseVolume(CACHE_ROOT, ui);
@@ -148,6 +160,10 @@ bool WipeData(Device* device) {
   }
   ui->Print("Data wipe %s.\n", success ? "complete" : "failed");
   return success;
+}
+
+bool WipeData(Device* device) {
+  return WipeData(device, volume_for_mount_point("/data")->fs_type);
 }
 
 bool WipeSystem(RecoveryUI* ui, const std::function<bool()>& confirm_func) {

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -44,6 +44,8 @@
 #include <cutils/properties.h> /* for property_list */
 #include <fs_mgr/roots.h>
 #include <volume_manager/VolumeManager.h>
+#include <hardware/boot_control.h>
+#include <hardware/hardware.h>
 #include <ziparchive/zip_archive.h>
 
 #include "bootloader_message/bootloader_message.h"
@@ -206,6 +208,43 @@ std::string get_preferred_fs(Device* device) {
       fs = items[chosen_item];
   }
   return fs;
+}
+
+std::string get_chosen_slot(Device* device) {
+  std::vector<std::string> headers{ "Choose which slot to boot into on next boot." };
+  std::vector<std::string> items{ "A", "B" };
+  size_t chosen_item = device->GetUI()->ShowMenu(
+      headers, items, 0, true,
+      std::bind(&Device::HandleMenuKey, device, std::placeholders::_1, std::placeholders::_2));
+  if (chosen_item < 0)
+    return "";
+  return items[chosen_item];
+}
+
+int set_slot(Device* device) {
+  std::string slot = get_chosen_slot(device);
+  if (slot == "")
+    return 0;
+  const hw_module_t *hw_module;
+  boot_control_module_t *module;
+  int ret;
+  ret = hw_get_module("bootctrl", &hw_module);
+  if (ret != 0) {
+    device->GetUI()->Print("Error getting bootctrl module.\n");
+  } else {
+    module = (boot_control_module_t*) hw_module;
+    module->init(module);
+    int slot_number = 0;
+    if (slot == "B")
+      slot_number = 1;
+    if (module->setActiveBootSlot(module, slot_number))
+      device->GetUI()->Print("Error changing bootloader boot slot to %s", slot.c_str());
+    else {
+      device->GetUI()->Print("Switched slot to %s.\n", slot.c_str());
+      device->GoHome();
+    }
+  }
+  return ret;
 }
 
 static bool ask_to_wipe_data(Device* device) {
@@ -613,6 +652,10 @@ change_menu:
         device->RemoveMenuItemForAction(Device::ENABLE_ADB);
         device->GoHome();
         ui->Print("Enabled ADB.\n");
+        break;
+
+      case Device::SWAP_SLOT:
+        set_slot(device);
         break;
 
       case Device::RUN_GRAPHICS_TEST:

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -41,11 +41,10 @@
 #include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <android-base/strings.h>
+#include <android/hardware/boot/1.0/IBootControl.h>
 #include <cutils/properties.h> /* for property_list */
 #include <fs_mgr/roots.h>
 #include <volume_manager/VolumeManager.h>
-#include <hardware/boot_control.h>
-#include <hardware/hardware.h>
 #include <ziparchive/zip_archive.h>
 
 #include "bootloader_message/bootloader_message.h"
@@ -70,7 +69,11 @@
 using android::volmgr::VolumeManager;
 using android::volmgr::VolumeInfo;
 
+using android::sp;
 using android::fs_mgr::Fstab;
+using android::hardware::boot::V1_0::IBootControl;
+using android::hardware::boot::V1_0::CommandResult;
+using android::hardware::boot::V1_0::Slot;
 
 static constexpr const char* COMMAND_FILE = "/cache/recovery/command";
 static constexpr const char* LAST_KMSG_FILE = "/cache/recovery/last_kmsg";
@@ -223,28 +226,22 @@ std::string get_chosen_slot(Device* device) {
 
 int set_slot(Device* device) {
   std::string slot = get_chosen_slot(device);
-  if (slot == "")
-    return 0;
-  const hw_module_t *hw_module;
-  boot_control_module_t *module;
-  int ret;
-  ret = hw_get_module("bootctrl", &hw_module);
-  if (ret != 0) {
+  CommandResult ret;
+  auto cb = [&ret](CommandResult result) { ret = result; };
+  Slot sslot = (slot == "A") ? 0 : 1;
+  sp<IBootControl> module = IBootControl::getService();
+  if (!module) {
     device->GetUI()->Print("Error getting bootctrl module.\n");
   } else {
-    module = (boot_control_module_t*) hw_module;
-    module->init(module);
-    int slot_number = 0;
-    if (slot == "B")
-      slot_number = 1;
-    if (module->setActiveBootSlot(module, slot_number))
-      device->GetUI()->Print("Error changing bootloader boot slot to %s", slot.c_str());
-    else {
+    auto result = module->setActiveBootSlot(sslot, cb);
+    if (result.isOk() && ret.success) {
       device->GetUI()->Print("Switched slot to %s.\n", slot.c_str());
       device->GoHome();
+    } else {
+      device->GetUI()->Print("Error changing bootloader boot slot to %s", slot.c_str());
     }
   }
-  return ret;
+  return ret.success ? 0 : 1;
 }
 
 static bool ask_to_wipe_data(Device* device) {

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -68,6 +68,8 @@
 using android::volmgr::VolumeManager;
 using android::volmgr::VolumeInfo;
 
+using android::fs_mgr::Fstab;
+
 static constexpr const char* COMMAND_FILE = "/cache/recovery/command";
 static constexpr const char* LAST_KMSG_FILE = "/cache/recovery/last_kmsg";
 static constexpr const char* LAST_LOG_FILE = "/cache/recovery/last_log";
@@ -185,9 +187,15 @@ bool ask_to_continue_downgrade(Device* device) {
 }
 
 std::string get_preferred_fs(Device* device) {
+  Fstab fstab;
+  auto read_fstab = ReadFstabFromFile("/etc/fstab", &fstab);
   std::vector<std::string> headers{ "Choose what filesystem you want to use on /data", "Entries here are supported by your device." };
-  std::vector<std::string> items = get_data_fs_items();
   std::string fs = volume_for_mount_point("/data")->fs_type;
+  if (read_fstab) {
+      std::string current_filesystem = android::fs_mgr::GetEntryForPath(&fstab, "/data")->fs_type;
+      headers.emplace_back("Current filesystem: " + current_filesystem);
+  }
+  std::vector<std::string> items = get_data_fs_items();
 
   if (items.size() > 1) {
       size_t chosen_item = device->GetUI()->ShowMenu(

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -184,6 +184,22 @@ bool ask_to_continue_downgrade(Device* device) {
   return yes_no(device, "This package will downgrade your system", "Install anyway?");
 }
 
+std::string get_preferred_fs(Device* device) {
+  std::vector<std::string> headers{ "Choose what filesystem you want to use on /data", "Entries here are supported by your device." };
+  std::vector<std::string> items = get_data_fs_items();
+  std::string fs = volume_for_mount_point("/data")->fs_type;
+
+  if (items.size() > 1) {
+      size_t chosen_item = device->GetUI()->ShowMenu(
+          headers, items, 0, true,
+          std::bind(&Device::HandleMenuKey, device, std::placeholders::_1, std::placeholders::_2));
+      if (chosen_item == Device::kGoBack)
+        return "";
+      fs = items[chosen_item];
+  }
+  return fs;
+}
+
 static bool ask_to_wipe_data(Device* device) {
   std::vector<std::string> headers{ "Format user data?", "This includes internal storage.", "THIS CANNOT BE UNDONE!" };
   std::vector<std::string> items{ " Cancel", " Format data" };
@@ -510,8 +526,11 @@ change_menu:
       case Device::WIPE_DATA:
         save_current_log = true;
         if (ui->IsTextVisible()) {
+          auto fs = get_preferred_fs(device);
+          if (fs == "")
+            break;
           if (ask_to_wipe_data(device)) {
-            WipeData(device);
+            WipeData(device, fs);
           }
         } else {
           WipeData(device);

--- a/recovery_main.cpp
+++ b/recovery_main.cpp
@@ -494,6 +494,10 @@ int main(int argc, char** argv) {
     device->RemoveMenuItemForAction(Device::ENABLE_ADB);
   }
 
+  if (!android::base::GetBoolProperty("ro.build.ab_update", false)) {
+    device->RemoveMenuItemForAction(Device::SWAP_SLOT);
+  }
+
   ui->SetBackground(RecoveryUI::NONE);
   if (show_text) ui->ShowText(true);
 

--- a/recovery_ui/device.cpp
+++ b/recovery_ui/device.cpp
@@ -45,6 +45,7 @@ static std::vector<menu_action_t> g_advanced_actions{
   { "Mount/unmount system", Device::MOUNT_SYSTEM },
   { "View recovery logs", Device::VIEW_RECOVERY_LOGS },
   { "Enable ADB", Device::ENABLE_ADB },
+  { "Switch slot", Device::SWAP_SLOT },
   { "Run graphics test", Device::RUN_GRAPHICS_TEST },
   { "Run locale test", Device::RUN_LOCALE_TEST },
   { "Enter rescue", Device::ENTER_RESCUE },

--- a/recovery_ui/include/recovery_ui/device.h
+++ b/recovery_ui/include/recovery_ui/device.h
@@ -71,6 +71,7 @@ class Device {
     SHUTDOWN_FROM_FASTBOOT = 21,
     WIPE_SYSTEM = 100,
     ENABLE_ADB = 101,
+    SWAP_SLOT = 102,
     MENU_BASE = 200,
     MENU_WIPE = 202,
     MENU_ADVANCED = 203,

--- a/recovery_utils/include/recovery_utils/roots.h
+++ b/recovery_utils/include/recovery_utils/roots.h
@@ -54,6 +54,13 @@ int format_volume(const std::string& volume);
 // Copies 'directory' to root of the newly formatted volume
 int format_volume(const std::string& volume, const std::string& directory);
 
+// Reformat the given volume (must be the mount point only, eg
+// "/cache"), no paths permitted.  Attempts to unmount the volume if
+// it is mounted.
+// Copies 'directory' to root of the newly formatted volume
+// Formats volume to fs
+int format_volume(const std::string& volume, const std::string& directory, const std::string fs);
+
 // Ensure that all and only the volumes that packages expect to find
 // mounted (/tmp and /cache) are mounted.  Returns 0 on success.
 int setup_install_mounts();
@@ -64,3 +71,5 @@ bool HasCache();
 void map_logical_partitions();
 
 bool logical_partitions_mapped();
+
+std::vector<std::string> get_data_fs_items();


### PR DESCRIPTION
Not sure exactly how to split this into two PRs when the changes in the first two commits end up impacting changes in the second set, and it's more useful to apply them sequentially.

But having fixed up the logic for formatting userdata as either f2fs or ext4 (and verifying that it works) now that the `convert_fbe` flags have been dropping in Android 13, it's nice to give folks the option on devices that support it... especially now that I'm shipping a kernel with AOSP 4.9 LTS updates included (including f2fs fixes).

Also, the slot-switching menu option seems to work fine on my enchilada & fajita, but they're both "hard" A/B, not virtual, and I don't have dynamic partitions (I'm only BOOT_HEADER_VERSION 1). So if it breaks things on newer devices, I can understand not wanting to include the patches.