### PR TITLE
recovery: modify build.version before loading

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -733,6 +733,23 @@ static void log_failure_code(ErrorCode code, const std::string& update_package) 
   LOG(INFO) << log_content;
 }
 
+std::string getProcessedVersion() {
+    std::string full_version = android::base::GetProperty("ro.crdroid.build.version", "(unknown)");
+    std::vector<std::string> parts;
+    std::stringstream ss(full_version);
+    std::string item;
+
+    while (std::getline(ss, item, '-')) {
+        parts.push_back(item);
+    }
+
+    if (parts.size() >= 5) {
+        return parts[0] + "-" + parts[1] + "-" + parts[2] + "-" + parts[4] + "-" + parts[5];
+    } else {
+        return "(unknown)";
+    }
+}
+
 Device::BuiltinAction start_recovery(Device* device, const std::vector<std::string>& args) {
   static constexpr struct option OPTIONS[] = {
     { "fastboot", no_argument, nullptr, 0 },
@@ -864,7 +881,7 @@ Device::BuiltinAction start_recovery(Device* device, const std::vector<std::stri
   std::string ver = android::base::GetProperty("ro.modversion", "");
 
   std::vector<std::string> title_lines = {
-    "Version " + android::base::GetProperty("ro.crdroid.build.version", "(unknown)"),
+    "Version " + getProcessedVersion(),
   };
   title_lines.push_back("Product name - " + android::base::GetProperty("ro.product.device", ""));
   if (android::base::GetBoolProperty("ro.build.ab_update", false)) {


### PR DESCRIPTION
This change makes long build.version string to not show device codename twice in recovery mode. This may fix issues on smaller screens when showing overlapping,

Change-Id: Ia7ab6ec2b6be9f7a30103bbbc1c7a381d01de3ea